### PR TITLE
feat: windows support and example

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ fn main() {
         .file("clipper2/clipper.offset.cpp")
         .file("clipper2/clipper.rectclip.cpp")
         .file("clipper2/wrapper.cpp")
+        .flag_if_supported("-std:c++17") // MSVC
         .flag_if_supported("-std=c++17")
         .compile("clipper2");
 

--- a/clipper2/wrapper.h
+++ b/clipper2/wrapper.h
@@ -6,6 +6,7 @@ extern "C"
 {
 #endif
 
+#include <stdint.h>
 #include <stdlib.h>
 
     typedef enum ClipTypeC

--- a/examples/union.rs
+++ b/examples/union.rs
@@ -1,0 +1,43 @@
+use clipper2::{Path, PathType, Polygon, Polygons, Vertex};
+
+fn main() {
+    let path1 = Path::new(
+        vec![
+            Vertex::new(0.1, 0.0),
+            Vertex::new(10.0, 0.0),
+            Vertex::new(10.0, 10.0),
+            Vertex::new(0.0, 10.0),
+        ],
+        true,
+    );
+    let path2 = Path::new(
+        vec![
+            Vertex::new(5.0, 5.0),
+            Vertex::new(15.0, 5.0),
+            Vertex::new(15.0, 15.0),
+            Vertex::new(5.0, 15.0),
+        ],
+        true,
+    );
+    let polygons = Polygons::new(vec![Polygon::new(
+        vec![path1.clone(), path2.clone()],
+        PathType::Subject,
+    )]);
+
+    let output = clipper2::union(polygons);
+    println!(
+        "Vertices: {}",
+        output
+            .polygons()
+            .first()
+            .unwrap()
+            .paths()
+            .first()
+            .unwrap()
+            .vertices()
+            .iter()
+            .map(|v| format!("({:.1}, {:.1})", v.x(), v.y()))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+}


### PR DESCRIPTION
1. Fixes issue with the windows compiler choosing the right ver
2. Fixes int64_t include on windows
3. Added very basic example (cargo run --example union)