### PR TITLE
Implement IntoIterator for Path/Paths

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -288,6 +288,15 @@ impl<'a, P: PointScaler> Iterator for PathIterator<'a, P> {
     }
 }
 
+impl<P: PointScaler> IntoIterator for Path<P> {
+    type Item = Point<P>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 impl<P: PointScaler> From<Path<P>> for Vec<Point<P>> {
     fn from(path: Path<P>) -> Self {
         path.0.clone()

--- a/src/path.rs
+++ b/src/path.rs
@@ -361,4 +361,12 @@ mod test {
         assert_eq!(path.0[1].x_scaled(), 1000);
         assert_eq!(path.0[1].y_scaled(), 1000);
     }
+
+    #[test]
+    fn test_into_iterator() {
+        let path = Path::<Centi>::from(vec![(0.0, 0.0), (1.0, 1.0)]);
+        for point in path {
+            assert_eq!(point.x(), point.y());
+        }
+    }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -388,4 +388,12 @@ mod test {
         assert_eq!(point2.x_scaled(), 1000);
         assert_eq!(point2.y_scaled(), 2000);
     }
+
+    #[test]
+    fn test_into_iterator() {
+        let paths = Paths::<Centi>::from(vec![vec![(0.0, 0.0), (1.0, 1.0)]; 2]);
+        for path in paths {
+            assert_eq!(path.len(), 2);
+        }
+    }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -267,6 +267,15 @@ impl<'a, P: PointScaler> Iterator for PathsIterator<'a, P> {
     }
 }
 
+impl<P: PointScaler> IntoIterator for Paths<P> {
+    type Item = Path<P>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 impl<P: PointScaler> From<Path<P>> for Paths<P> {
     fn from(path: Path<P>) -> Self {
         vec![path].into()


### PR DESCRIPTION
Implement `IntoIterator` for `Path` and `Paths`, as a convenience when using `for` loops.