### PR TITLE
Support calculating signed path areas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "clipper2c-sys"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d107914075091bd59b009c16cc46f84e61886014213c4e36cabd3637d4466228"
+checksum = "f06383cd1fbc664e6900676c903ae0398ba8b3187372cffda1be8d34d93133ec"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ doc-images = []
 
 [dependencies]
 libc = "0.2"
-clipper2c-sys = "0.1.0"
+clipper2c-sys = "0.1.1"
 thiserror = "1.0.59"
 
 [dev-dependencies]

--- a/src/path.rs
+++ b/src/path.rs
@@ -299,6 +299,15 @@ impl<'a, P: PointScaler> Iterator for PathIterator<'a, P> {
     }
 }
 
+impl<P: PointScaler> IntoIterator for Path<P> {
+    type Item = Point<P>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 impl<P: PointScaler> From<Path<P>> for Vec<Point<P>> {
     fn from(path: Path<P>) -> Self {
         path.0.clone()
@@ -362,5 +371,13 @@ mod test {
         assert_eq!(path.0[0].y_scaled(), 0);
         assert_eq!(path.0[1].x_scaled(), 1000);
         assert_eq!(path.0[1].y_scaled(), 1000);
+    }
+
+    #[test]
+    fn test_into_iterator() {
+        let path = Path::<Centi>::from(vec![(0.0, 0.0), (1.0, 1.0)]);
+        for point in path {
+            assert_eq!(point.x(), point.y());
+        }
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -43,6 +43,17 @@ impl<P: PointScaler> Path<P> {
         self.is_empty()
     }
 
+    /// Creates a path in a rectangle shape
+    pub fn rectangle(x: f64, y: f64, size_x: f64, size_y: f64) -> Self {
+        vec![
+            (x, y),
+            (x + size_x, y),
+            (x + size_x, y + size_y),
+            (x, y + size_y),
+        ]
+        .into()
+    }
+
     /// Returns an iterator over the points in the path.
     pub fn iter(&self) -> PathIterator<P> {
         PathIterator {

--- a/src/path.rs
+++ b/src/path.rs
@@ -407,4 +407,18 @@ mod test {
             assert_eq!(point.x(), point.y());
         }
     }
+
+    #[test]
+    fn test_signed_area() {
+        let path = Path::<Centi>::rectangle(10.0, 20.0, 30.0, 15.0);
+        let area = path.signed_area();
+        assert_eq!(area, 450.0);
+    }
+
+    #[test]
+    fn test_signed_area_negative() {
+        let path = Path::<Centi>::rectangle(-20.0, 25.0, -40.0, 30.0);
+        let area = path.signed_area();
+        assert_eq!(area, -1200.0);
+    }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,5 +1,5 @@
 use clipper2c_sys::{
-    clipper_delete_path64, clipper_path64_get_point, clipper_path64_length,
+    clipper_delete_path64, clipper_path64_area, clipper_path64_get_point, clipper_path64_length,
     clipper_path64_of_points, clipper_path64_simplify, clipper_path64_size, ClipperPath64,
     ClipperPoint64,
 };
@@ -249,6 +249,33 @@ impl<P: PointScaler> Path<P> {
     /// For more details see the original [point-in-polygon](https://www.angusj.com/clipper2/Docs/Units/Clipper/Functions/PointInPolygon.htm) docs.
     pub fn is_point_inside(&self, point: Point<P>) -> PointInPolygonResult {
         point_in_polygon(point, self)
+    }
+
+    /// This function returns the area of the supplied polygon. It's assumed
+    /// that the path is closed and does not self-intersect.
+    ///
+    /// Depending on the path's winding orientation, this value may be positive
+    /// or negative. Assuming paths are displayed in a Cartesian plane (with X
+    /// values increasing heading right and Y values increasing heading up) then
+    /// clockwise winding will have negative areas and counter-clockwise winding
+    /// have positive areas.
+    ///
+    /// Conversely, when paths are displayed where Y values increase heading
+    /// down, then clockwise paths will have positive areas, and
+    /// counter-clockwise paths will have negative areas.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use clipper2::*;
+    ///
+    /// let path: Path = vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)].into();
+    ///
+    /// assert_eq!(path.signed_area(), 1.0);
+    /// ```
+    ///
+    pub fn signed_area(&self) -> f64 {
+        unsafe { clipper_path64_area(self.to_clipperpath64()) / (P::MULTIPLIER * P::MULTIPLIER) }
     }
 
     pub(crate) fn from_clipperpath64(ptr: *mut ClipperPath64) -> Self {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,5 +1,5 @@
 use clipper2c_sys::{
-    clipper_delete_path64, clipper_paths64_get_point, clipper_paths64_length,
+    clipper_delete_path64, clipper_paths64_area, clipper_paths64_get_point, clipper_paths64_length,
     clipper_paths64_of_paths, clipper_paths64_path_length, clipper_paths64_size, ClipperPath64,
     ClipperPaths64,
 };
@@ -212,6 +212,33 @@ impl<P: PointScaler> Paths<P> {
     pub fn to_clipper_open_subject(&self) -> Clipper<WithSubjects, P> {
         let clipper = Clipper::new();
         clipper.add_open_subject(self.clone())
+    }
+
+    /// This function returns the area of the supplied paths. It's assumed
+    /// that the paths are closed and do not self-intersect.
+    ///
+    /// Depending on the paths' winding orientations, this value may be positive
+    /// or negative. Assuming paths are displayed in a Cartesian plane (with X
+    /// values increasing heading right and Y values increasing heading up) then
+    /// clockwise winding will have negative areas and counter-clockwise winding
+    /// have positive areas.
+    ///
+    /// Conversely, when paths are displayed where Y values increase heading
+    /// down, then clockwise paths will have positive areas, and
+    /// counter-clockwise paths will have negative areas.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use clipper2::*;
+    ///
+    /// let paths: Paths = vec![vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]].into();
+    ///
+    /// assert_eq!(paths.signed_area(), 1.0);
+    /// ```
+    ///
+    pub fn signed_area(&self) -> f64 {
+        unsafe { clipper_paths64_area(self.to_clipperpaths64()) / (P::MULTIPLIER * P::MULTIPLIER) }
     }
 
     pub(crate) fn from_clipperpaths64(ptr: *mut ClipperPaths64) -> Self {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -267,6 +267,15 @@ impl<'a, P: PointScaler> Iterator for PathsIterator<'a, P> {
     }
 }
 
+impl<P: PointScaler> IntoIterator for Paths<P> {
+    type Item = Path<P>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 impl<P: PointScaler> From<Path<P>> for Paths<P> {
     fn from(path: Path<P>) -> Self {
         vec![path].into()
@@ -378,5 +387,13 @@ mod test {
         assert_eq!(point1.y_scaled(), 600);
         assert_eq!(point2.x_scaled(), 1000);
         assert_eq!(point2.y_scaled(), 2000);
+    }
+
+    #[test]
+    fn test_into_iterator() {
+        let paths = Paths::<Centi>::from(vec![vec![(0.0, 0.0), (1.0, 1.0)]; 2]);
+        for path in paths {
+            assert_eq!(path.len(), 2);
+        }
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -423,4 +423,34 @@ mod test {
             assert_eq!(path.len(), 2);
         }
     }
+
+    #[test]
+    fn test_signed_area() {
+        let paths = Paths::new(vec![
+            Path::<Centi>::rectangle(10.0, 20.0, 30.0, 150.0),
+            Path::<Centi>::rectangle(40.0, 20.0, 10.0, 15.0),
+        ]);
+        let area = paths.signed_area();
+        assert_eq!(area, 4650.0);
+    }
+
+    #[test]
+    fn test_signed_area_negative() {
+        let paths = Paths::new(vec![
+            Path::<Centi>::rectangle(-20.0, 25.0, -45.0, 30.0),
+            Path::<Centi>::rectangle(-20.0, 55.0, 15.0, 15.0),
+        ]);
+        let area = paths.signed_area();
+        assert_eq!(area, -1125.0);
+    }
+
+    #[test]
+    fn test_signed_area_counts_overlapping_areas_comulatively_for_each_path() {
+        let paths = Paths::new(vec![
+            Path::<Centi>::rectangle(10.0, 20.0, 30.0, 150.0),
+            Path::<Centi>::rectangle(10.0, 20.0, 100.0, 15.0),
+        ]);
+        let area = paths.signed_area();
+        assert_eq!(area, 6000.0);
+    }
 }


### PR DESCRIPTION
Depends on https://github.com/tirithen/clipper2c-sys/pull/1 to be merged first.

Supports calculating signed polygon areas.