### PR TITLE
Support scaling around a point

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,29 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: cargo test
+  test_all_features:
+    name: cargo test (all features)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo test --all-features
+
+  test_no_features:
+    name: cargo test (no features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo test
+
+  test_serde_feature:
+    name: cargo test (serde)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo test --features serde
 
   # Check formatting with rustfmt
   formatting:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,17 +76,20 @@ dependencies = [
  "embed-doc-image",
  "libc",
  "macroquad",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
 [[package]]
 name = "clipper2c-sys"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f06383cd1fbc664e6900676c903ae0398ba8b3187372cffda1be8d34d93133ec"
+checksum = "94f103dc502f24d06fd9850e463fe7a2f505b7b40c087d2cb17046afb0413d45"
 dependencies = [
  "cc",
  "libc",
+ "serde",
 ]
 
 [[package]]
@@ -172,6 +175,12 @@ dependencies = [
  "num-traits",
  "png",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
@@ -297,6 +306,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "serde"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "clipper2c-sys"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d107914075091bd59b009c16cc46f84e61886014213c4e36cabd3637d4466228"
+checksum = "f06383cd1fbc664e6900676c903ae0398ba8b3187372cffda1be8d34d93133ec"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,18 @@ categories = ["algorithms"]
 [features]
 default = ["doc-images"]
 doc-images = []
+serde = ["dep:serde", "clipper2c-sys/serde"]
 
 [dependencies]
 libc = "0.2"
-clipper2c-sys = "0.1.1"
+clipper2c-sys = "0.1.2"
 thiserror = "1.0.59"
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 macroquad = "0.4.5"
 embed-doc-image = "0.1"
+serde_json = "1"
 
 [package.metadata.docs.rs]
 # docs.rs uses a nightly compiler, so by instructing it to use our `doc-images` feature we

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ doc-images = []
 
 [dependencies]
 libc = "0.2"
-clipper2c-sys = "0.1.0"
+clipper2c-sys = "0.1.1"
 thiserror = "1.0.59"
 
 [dev-dependencies]

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,15 +1,15 @@
-use crate::Point;
+use crate::{Centi, Point, PointScaler};
 
 /// Represents an area from one min and one max [Point](struct.Point.html).
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
-pub struct Bounds {
+pub struct Bounds<P: PointScaler = Centi> {
     /// Minimum point of the boundary.
-    pub min: Point,
+    pub min: Point<P>,
     /// Maximum point of the boundary.
-    pub max: Point,
+    pub max: Point<P>,
 }
 
-impl Bounds {
+impl<P: PointScaler> Bounds<P> {
     /// Create a `Bounds` struct starting at xy 0.0 and ending at the given xy
     /// coordinates.
     #[must_use]
@@ -32,13 +32,13 @@ impl Bounds {
 
     /// Return the size of the bounds area as a [Point](struct.Point.html).
     #[must_use]
-    pub fn size(&self) -> Point {
+    pub fn size(&self) -> Point<P> {
         Point::new(self.max.x() - self.min.x(), self.max.y() - self.min.y())
     }
 
     /// Return the center of the bounds area as a [Point](struct.Point.html).
     #[must_use]
-    pub fn center(&self) -> Point {
+    pub fn center(&self) -> Point<P> {
         let size = self.size();
         Point::new(self.min.x() + size.x() / 2.0, self.min.y() + size.y() / 2.0)
     }

--- a/src/path.rs
+++ b/src/path.rs
@@ -299,6 +299,15 @@ impl<'a, P: PointScaler> Iterator for PathIterator<'a, P> {
     }
 }
 
+impl<P: PointScaler> IntoIterator for Path<P> {
+    type Item = Point<P>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 impl<P: PointScaler> From<Path<P>> for Vec<Point<P>> {
     fn from(path: Path<P>) -> Self {
         path.0.clone()
@@ -362,5 +371,13 @@ mod test {
         assert_eq!(path.0[0].y_scaled(), 0);
         assert_eq!(path.0[1].x_scaled(), 1000);
         assert_eq!(path.0[1].y_scaled(), 1000);
+    }
+
+    #[test]
+    fn test_into_iterator() {
+        let path = Path::<Centi>::from(vec![(0.0, 0.0), (1.0, 1.0)]);
+        for point in path {
+            assert_eq!(point.x(), point.y());
+        }
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -43,6 +43,17 @@ impl<P: PointScaler> Path<P> {
         self.is_empty()
     }
 
+    /// Creates a path in a rectangle shape
+    pub fn rectangle(x: f64, y: f64, size_x: f64, size_y: f64) -> Self {
+        vec![
+            (x, y),
+            (x + size_x, y),
+            (x + size_x, y + size_y),
+            (x, y + size_y),
+        ]
+        .into()
+    }
+
     /// Returns an iterator over the points in the path.
     pub fn iter(&self) -> PathIterator<P> {
         PathIterator {

--- a/src/path.rs
+++ b/src/path.rs
@@ -84,17 +84,39 @@ impl<P: PointScaler> Path<P> {
     }
 
     /// Construct a scaled clone of the path with the origin at the path center
-    pub fn scale(&self, scale: f64) -> Self {
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use clipper2::Path;
+    /// let path: Path = vec![(-1.0, -1.0), (1.0, 1.0)].into();
+    /// let scaled = path.scale(2.0, 2.0);
+    /// assert_eq!(scaled.iter().map(|p| (p.x(), p.y())).collect::<Vec<_>>(), vec![(-2.0, -2.0), (2.0, 2.0)]);
+    /// ```
+    pub fn scale(&self, scale_x: f64, scale_y: f64) -> Self {
         let bounds = self.bounds();
         let center = bounds.center();
+        self.scale_around_point(scale_x, scale_y, center)
+    }
 
+    /// Construct a scaled clone of the path with the origin at a given point
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use clipper2::Path;
+    /// let path: Path = vec![(0.0, 0.0), (1.0, 1.0)].into();
+    /// let scaled = path.scale_around_point(2.0, 2.0, (0.0, 0.0).into());
+    /// assert_eq!(scaled.iter().map(|p| (p.x(), p.y())).collect::<Vec<_>>(), vec![(0.0, 0.0), (2.0, 2.0)]);
+    /// ```
+    pub fn scale_around_point(&self, scale_x: f64, scale_y: f64, point: Point<P>) -> Self {
         Self::new(
             self.0
                 .iter()
                 .map(|p| {
                     Point::<P>::new(
-                        (center.x() - p.x()) * scale + center.x(),
-                        (center.y() - p.y()) * scale + center.y(),
+                        (p.x() - point.x()) * scale_x + point.x(),
+                        (p.y() - point.y()) * scale_y + point.y(),
                     )
                 })
                 .collect(),
@@ -148,7 +170,7 @@ impl<P: PointScaler> Path<P> {
     }
 
     /// Returns the bounds for this path
-    pub fn bounds(&self) -> Bounds {
+    pub fn bounds(&self) -> Bounds<P> {
         let mut bounds = Bounds::minmax();
 
         for p in &self.0 {

--- a/src/path.rs
+++ b/src/path.rs
@@ -94,8 +94,7 @@ impl<P: PointScaler> Path<P> {
     /// assert_eq!(scaled.iter().map(|p| (p.x(), p.y())).collect::<Vec<_>>(), vec![(-2.0, -2.0), (2.0, 2.0)]);
     /// ```
     pub fn scale(&self, scale_x: f64, scale_y: f64) -> Self {
-        let bounds = self.bounds();
-        let center = bounds.center();
+        let center = self.bounds().center();
         self.scale_around_point(scale_x, scale_y, center)
     }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -19,7 +19,12 @@ use crate::{
 /// let path_from_tuples: Path = vec![(0.0, 0.0), (5.0, 0.0), (5.0, 6.0), (0.0, 6.0)].into();
 /// let path_from_slices: Path = vec![[0.0, 0.0], [5.0, 0.0], [5.0, 6.0], [0.0, 6.0]].into();
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound = "P: PointScaler")
+)]
 pub struct Path<P: PointScaler = Centi>(Vec<Point<P>>);
 
 impl<P: PointScaler> Path<P> {
@@ -420,5 +425,16 @@ mod test {
         let path = Path::<Centi>::rectangle(-20.0, 25.0, -40.0, 30.0);
         let area = path.signed_area();
         assert_eq!(area, -1200.0);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde() {
+        let path = Path::<Centi>::from(vec![(0.0, 0.0), (1.0, 1.0)]);
+        let serialized = serde_json::to_string(&path).unwrap();
+        assert_eq!(serialized, r#"[{"x":0,"y":0},{"x":100,"y":100}]"#);
+
+        let deserialized: Path<Centi> = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, path);
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -19,7 +19,12 @@ use crate::{
 /// let paths_from_single_vec: Paths = vec![(0.0, 0.0), (5.0, 0.0), (5.0, 6.0), (0.0, 6.0)].into();
 /// let paths_from_vec_of_vecs: Paths = vec![vec![(0.0, 0.0), (5.0, 0.0), (5.0, 6.0), (0.0, 6.0)]].into();
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound = "P: PointScaler")
+)]
 pub struct Paths<P: PointScaler = Centi>(Vec<Path<P>>);
 
 impl<P: PointScaler> Paths<P> {
@@ -452,5 +457,16 @@ mod test {
         ]);
         let area = paths.signed_area();
         assert_eq!(area, 6000.0);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde() {
+        let paths = Paths::<Centi>::from(vec![(0.4, 0.0), (5.0, 1.0)]);
+        let serialized = serde_json::to_string(&paths).unwrap();
+        assert_eq!(serialized, r#"[[{"x":40,"y":0},{"x":500,"y":100}]]"#);
+
+        let deserialized: Paths<Centi> = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, paths);
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -86,8 +86,18 @@ impl<P: PointScaler> Paths<P> {
     }
 
     /// Construct a scaled clone of the path with the origin at the path center.
-    pub fn scale(&self, scale: f64) -> Self {
-        Self::new(self.0.iter().map(|p| p.scale(scale)).collect())
+    pub fn scale(&self, scale_x: f64, scale_y: f64) -> Self {
+        Self::new(self.0.iter().map(|p| p.scale(scale_x, scale_y)).collect())
+    }
+
+    /// Construct a scaled clone of the path with the origin at a given point.
+    pub fn scale_around_point(&self, scale_x: f64, scale_y: f64, point: Point<P>) -> Self {
+        Self::new(
+            self.0
+                .iter()
+                .map(|p| p.scale_around_point(scale_x, scale_y, point))
+                .collect(),
+        )
     }
 
     /// Construct a rotated clone of the path with the origin at the path

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -267,6 +267,15 @@ impl<'a, P: PointScaler> Iterator for PathsIterator<'a, P> {
     }
 }
 
+impl<P: PointScaler> IntoIterator for Paths<P> {
+    type Item = Path<P>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 impl<P: PointScaler> From<Path<P>> for Paths<P> {
     fn from(path: Path<P>) -> Self {
         vec![path].into()
@@ -378,5 +387,13 @@ mod test {
         assert_eq!(point1.y_scaled(), 600);
         assert_eq!(point2.x_scaled(), 1000);
         assert_eq!(point2.y_scaled(), 2000);
+    }
+
+    #[test]
+    fn test_into_iterator() {
+        let paths = Paths::<Centi>::from(vec![vec![(0.0, 0.0), (1.0, 1.0)]; 2]);
+        for path in paths {
+            assert_eq!(path.len(), 2);
+        }
     }
 }


### PR DESCRIPTION
Provides the convenience function `scale_around_point` (like [geo](https://docs.rs/geo/latest/geo/algorithm/scale/trait.Scale.html#tymethod.scale_around_point)), and also supports scaling non-uniformly.

I also made `Bounds` depend on `PointScaler`, which fixed some type issues for me.